### PR TITLE
feat(secrets): age encryption and per-service redaction

### DIFF
--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -1,0 +1,104 @@
+package secrets
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"filippo.io/age"
+)
+
+type Store struct {
+	identity *age.X25519Identity
+	secrets  map[string][][]byte // serviceID -> encrypted values
+}
+
+func NewStore(privateKey string) (*Store, error) {
+	ids, err := age.ParseIdentities(strings.NewReader(privateKey))
+	if err != nil {
+		return nil, fmt.Errorf("parse identity: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no identity parsed")
+	}
+	xid, ok := ids[0].(*age.X25519Identity)
+	if !ok {
+		return nil, fmt.Errorf("identity is not X25519")
+	}
+	return &Store{identity: xid, secrets: make(map[string][][]byte)}, nil
+}
+
+func (s *Store) Encrypt(plaintext []byte) ([]byte, error) {
+	recipient := s.identity.Recipient()
+	var buf bytes.Buffer
+	w, err := age.Encrypt(&buf, recipient)
+	if err != nil {
+		return nil, fmt.Errorf("age encrypt: %w", err)
+	}
+	if _, err := io.Copy(w, bytes.NewReader(plaintext)); err != nil {
+		w.Close()
+		return nil, fmt.Errorf("write plaintext: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("close encrypt: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (s *Store) Decrypt(ciphertext []byte) ([]byte, error) {
+	r, err := age.Decrypt(bytes.NewReader(ciphertext), s.identity)
+	if err != nil {
+		return nil, fmt.Errorf("age decrypt: %w", err)
+	}
+	plain, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read plaintext: %w", err)
+	}
+	return plain, nil
+}
+
+type Redactor interface {
+	Redact(s string) string
+}
+
+type replacer struct {
+	r *strings.Replacer
+}
+
+func NewRedactor(secrets ...string) Redactor {
+	pairs := make([]string, 0, len(secrets)*2)
+	for _, s := range secrets {
+		pairs = append(pairs, s, "[REDACTED]")
+	}
+	return &replacer{r: strings.NewReplacer(pairs...)}
+}
+
+func (r *replacer) Redact(s string) string {
+	return r.r.Replace(s)
+}
+
+func (s *Store) RegisterSecret(serviceID string, plaintext []byte) error {
+	enc, err := s.Encrypt(plaintext)
+	if err != nil {
+		return fmt.Errorf("register secret: %w", err)
+	}
+	s.secrets[serviceID] = append(s.secrets[serviceID], enc)
+	return nil
+}
+
+func (s *Store) RedactorFor(serviceID string) (Redactor, error) {
+	encrypted, ok := s.secrets[serviceID]
+	if !ok {
+		return NewRedactor(), nil
+	}
+	secrets := make([]string, 0, len(encrypted))
+	for _, enc := range encrypted {
+		plain, err := s.Decrypt(enc)
+		if err != nil {
+			return nil, fmt.Errorf("redactor for %s: %w", serviceID, err)
+		}
+		secrets = append(secrets, string(plain))
+	}
+	return NewRedactor(secrets...), nil
+}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -1,0 +1,130 @@
+package secrets_test
+
+import (
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/LoriKarikari/paastry/internal/secrets"
+)
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	store, err := secrets.NewStore(identity.String())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	plain := "postgres://user:s3cret@host:5432/mydb"
+	enc, err := store.Encrypt([]byte(plain))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if len(enc) == 0 {
+		t.Fatal("ciphertext is empty")
+	}
+	if strings.Contains(string(enc), plain) {
+		t.Fatal("ciphertext contains plaintext")
+	}
+
+	dec, err := store.Decrypt(enc)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(dec) != plain {
+		t.Fatalf("decrypted %q, want %q", dec, plain)
+	}
+}
+
+func TestRedactorFullMatch(t *testing.T) {
+	r := secrets.NewRedactor("postgres://user:s3cret@host:5432/mydb", "redis://:auth@cache:6379")
+	out := r.Redact("connect to postgres://user:s3cret@host:5432/mydb and redis://:auth@cache:6379")
+	if strings.Contains(out, "s3cret") {
+		t.Fatalf("secret leaked: %s", out)
+	}
+	if strings.Contains(out, "auth@cache") {
+		t.Fatalf("secret leaked: %s", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("no redaction marker: %s", out)
+	}
+}
+
+func TestRedactorPartialMatch(t *testing.T) {
+	r := secrets.NewRedactor("s3cret", "auth")
+	out := r.Redact("postgres://user:s3cret@host:5432/db?password=s3cret")
+	if strings.Contains(out, "s3cret") {
+		t.Fatalf("secret leaked: %s", out)
+	}
+	if strings.Contains(out, "auth") && !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("secret leaked: %s", out)
+	}
+}
+
+func TestRedactorNoSecrets(t *testing.T) {
+	r := secrets.NewRedactor()
+	out := r.Redact("nothing sensitive here")
+	if out != "nothing sensitive here" {
+		t.Fatalf("unexpected redaction: %s", out)
+	}
+}
+
+func TestRedactorEmpty(t *testing.T) {
+	r := secrets.NewRedactor("secret")
+	out := r.Redact("")
+	if out != "" {
+		t.Fatalf("got %q, want empty", out)
+	}
+}
+
+func TestRedactorFor(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	store, err := secrets.NewStore(identity.String())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	if err := store.RegisterSecret("svc-1", []byte("postgres://user:s3cret@host:5432/db")); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := store.RegisterSecret("svc-1", []byte("redis://:auth-token@cache:6379")); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	r, err := store.RedactorFor("svc-1")
+	if err != nil {
+		t.Fatalf("redactor for: %v", err)
+	}
+
+	out := r.Redact("connecting to postgres://user:s3cret@host:5432/db then redis://:auth-token@cache:6379")
+	if strings.Contains(out, "s3cret") || strings.Contains(out, "auth-token") {
+		t.Fatalf("secret leaked: %s", out)
+	}
+}
+
+func TestRedactorForNoSecrets(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	store, err := secrets.NewStore(identity.String())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	r, err := store.RedactorFor("unknown-svc")
+	if err != nil {
+		t.Fatalf("redactor for: %v", err)
+	}
+	out := r.Redact("nothing to redact")
+	if out != "nothing to redact" {
+		t.Fatalf("got %q", out)
+	}
+}


### PR DESCRIPTION
Closes #6.

- age X25519 keypair for encrypt/decrypt
- RegisterSecret stores encrypted per-service values
- RedactorFor decrypts on every read — no caching
- Redactor masks full connection strings and substrings