### PR TITLE
feat(service): DB persistence, named volumes, GetService/ListServices

### DIFF
--- a/cmd/paastry/main_test.go
+++ b/cmd/paastry/main_test.go
@@ -303,6 +303,55 @@ func TestRunServerListsDefaultTenant(t *testing.T) {
 	}
 }
 
+func TestRunServerProvisionsAndListsServices(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	port := freePort(t)
+	getenv := func(key string) string {
+		switch key {
+		case "PAASTRY_HOME":
+			return home
+		case "HOST":
+			return "127.0.0.1"
+		case "PORT":
+			return port
+		default:
+			return ""
+		}
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := run(context.Background(), &stdout, &stderr, []string{"paastry", "init"}, getenv); err != nil {
+		t.Fatalf("run init: %v\nstderr: %s", err, stderr.String())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- run(ctx, &stdout, &stderr, []string{"paastry", "server"}, getenv)
+	}()
+	waitForHealthz(t, port, &stderr)
+
+	client := paastryv1connect.NewServiceServiceClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%s", port))
+
+	// Provision fails without Docker — but we can at least test ListServices returns empty.
+	res, err := client.ListServices(context.Background(), connect.NewRequest(&paastryv1.ListServicesRequest{TenantId: "tenant-default"}))
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	if len(res.Msg.Services) != 0 {
+		t.Fatalf("services count = %d, want 0 (no Docker in test)", len(res.Msg.Services))
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("server shutdown: %v", err)
+	}
+}
+
 func waitForHealthz(t *testing.T, port string, stderr *bytes.Buffer) {
 	t.Helper()
 

--- a/cmd/paastry/run.go
+++ b/cmd/paastry/run.go
@@ -164,32 +164,108 @@ func (h serviceHandler) ProvisionService(
 	ctx context.Context,
 	req *connect.Request[paastryv1.ProvisionServiceRequest],
 ) (*connect.Response[paastryv1.ProvisionServiceResponse], error) {
-	svc, err := h.manager.Provision(ctx, service.ProvisionSpec{
+	spec := service.ProvisionSpec{
 		Name:       req.Msg.Name,
 		TenantID:   req.Msg.TenantId,
 		Network:    "paastry-tenant-default",
 		DBName:     "app",
 		DBUser:     "app",
 		DBPassword: "changeme",
-	})
+	}
+
+	svc, err := h.manager.Provision(ctx, spec)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("provision service: %w", err))
 	}
+
+	_, err = h.db.ExecContext(ctx,
+		`insert into services (id, tenant_id, name, type, state) values (?, ?, ?, ?, ?)`,
+		svc.Id, spec.TenantID, spec.Name, "postgres", svc.State.String(),
+	)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("persist service: %w", err))
+	}
+
 	return connect.NewResponse(&paastryv1.ProvisionServiceResponse{Service: svc}), nil
 }
 
 func (h serviceHandler) GetService(
-	_ context.Context,
-	_ *connect.Request[paastryv1.GetServiceRequest],
+	ctx context.Context,
+	req *connect.Request[paastryv1.GetServiceRequest],
 ) (*connect.Response[paastryv1.GetServiceResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("get service not implemented"))
+	svc := &paastryv1.Service{}
+	var typeStr, stateStr string
+	err := h.db.QueryRowContext(ctx,
+		`select id, tenant_id, name, type, state from services where id = ?`,
+		req.Msg.ServiceId,
+	).Scan(&svc.Id, &svc.TenantId, &svc.Name, &typeStr, &stateStr)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("service not found"))
+	}
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get service: %w", err))
+	}
+	svc.Type = parseServiceType(typeStr)
+	svc.State = parseServiceState(stateStr)
+	return connect.NewResponse(&paastryv1.GetServiceResponse{Service: svc}), nil
 }
 
 func (h serviceHandler) ListServices(
-	_ context.Context,
-	_ *connect.Request[paastryv1.ListServicesRequest],
+	ctx context.Context,
+	req *connect.Request[paastryv1.ListServicesRequest],
 ) (*connect.Response[paastryv1.ListServicesResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("list services not implemented"))
+	rows, err := h.db.QueryContext(ctx,
+		`select id, tenant_id, name, type, state from services where tenant_id = ? order by name`,
+		req.Msg.TenantId,
+	)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list services: %w", err))
+	}
+	defer rows.Close()
+
+	var services []*paastryv1.Service
+	for rows.Next() {
+		svc := &paastryv1.Service{}
+		var typeStr, stateStr string
+		if err := rows.Scan(&svc.Id, &svc.TenantId, &svc.Name, &typeStr, &stateStr); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scan service: %w", err))
+		}
+		svc.Type = parseServiceType(typeStr)
+		svc.State = parseServiceState(stateStr)
+		services = append(services, svc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("iterate services: %w", err))
+	}
+	return connect.NewResponse(&paastryv1.ListServicesResponse{Services: services}), nil
+}
+
+func parseServiceType(s string) paastryv1.ServiceType {
+	switch s {
+	case "postgres":
+		return paastryv1.ServiceType_SERVICE_TYPE_POSTGRES
+	case "redis":
+		return paastryv1.ServiceType_SERVICE_TYPE_REDIS
+	case "valkey":
+		return paastryv1.ServiceType_SERVICE_TYPE_VALKEY
+	default:
+		return paastryv1.ServiceType_SERVICE_TYPE_UNSPECIFIED
+	}
+}
+
+func parseServiceState(s string) paastryv1.ServiceState {
+	switch s {
+	case "provisioning":
+		return paastryv1.ServiceState_SERVICE_STATE_PROVISIONING
+	case "running":
+		return paastryv1.ServiceState_SERVICE_STATE_RUNNING
+	case "failed":
+		return paastryv1.ServiceState_SERVICE_STATE_FAILED
+	case "deprovisioned":
+		return paastryv1.ServiceState_SERVICE_STATE_DEPROVISIONED
+	default:
+		return paastryv1.ServiceState_SERVICE_STATE_UNSPECIFIED
+	}
 }
 
 func (h tenantHandler) ListTenants(
@@ -273,6 +349,16 @@ func initializeDatabase(path string) error {
 		insert into tenants (id, name, network_name)
 		values ('tenant-default', 'default', 'paastry-tenant-default')
 		on conflict(name) do nothing;
+
+		create table if not exists services (
+			id text primary key,
+			tenant_id text not null,
+			name text not null,
+			type text not null,
+			state text not null default 'provisioning',
+			created_at text not null default current_timestamp,
+			unique(tenant_id, name)
+		);
 	`); err != nil {
 		return fmt.Errorf("initialize sqlite database: %w", err)
 	}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/netip"
 
+	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
@@ -26,11 +27,17 @@ type Network struct {
 	Name string
 }
 
+type Mount struct {
+	Source string
+	Target string
+}
+
 type ServiceCreateSpec struct {
 	Name    string
 	Image   string
 	Env     []string
 	Network string
+	Mounts  []Mount
 }
 
 type Service struct {
@@ -93,12 +100,18 @@ func (c *Client) NetworkRemove(ctx context.Context, id string) error {
 }
 
 func (c *Client) ServiceCreate(ctx context.Context, spec ServiceCreateSpec) (*Service, error) {
-	task := swarm.TaskSpec{
-		ContainerSpec: &swarm.ContainerSpec{
-			Image: spec.Image,
-			Env:   spec.Env,
-		},
+	cspec := &swarm.ContainerSpec{
+		Image: spec.Image,
+		Env:   spec.Env,
 	}
+	for _, m := range spec.Mounts {
+		cspec.Mounts = append(cspec.Mounts, mount.Mount{
+			Type:   mount.TypeVolume,
+			Source: m.Source,
+			Target: m.Target,
+		})
+	}
+	task := swarm.TaskSpec{ContainerSpec: cspec}
 	if spec.Network != "" {
 		task.Networks = []swarm.NetworkAttachmentConfig{{Target: spec.Network}}
 	}

--- a/internal/service/postgres.go
+++ b/internal/service/postgres.go
@@ -30,6 +30,9 @@ func (m *postgresManager) Provision(ctx context.Context, spec ProvisionSpec) (*p
 			"POSTGRES_USER=" + spec.DBUser,
 			"POSTGRES_PASSWORD=" + spec.DBPassword,
 		},
+		Mounts: []docker.Mount{
+			{Source: "paastry-pg-" + spec.Name + "-data", Target: "/var/lib/postgresql/data"},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create postgres service: %w", err)


### PR DESCRIPTION
Closes #7.

- `services` table in SQLite schema
- `GetService` and `ListServices` handlers with DB queries
- `Docker.Mount` type and `ServiceCreateSpec.Mounts` for named volumes
- Postgres provision mounts `paastry-pg-{name}-data` → `/var/lib/postgresql/data`