### PR TITLE
feat(app): deploy apps from pre-built images

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,13 +23,13 @@ The backend is written in Go and orchestrates infrastructure tooling via the Doc
 
 ## Language
 
-**Service**: A deployed workload managed by PaaStry. Can be a user App or a managed dependency (Postgres, Redis, etc.). Implements at least `ServiceManager`.
+**Service**: A deployed workload managed by PaaStry as a Docker Swarm service. Can be a user App or a managed dependency (Postgres, Redis, etc.). Its lifecycle includes validation, tenant network resolution, provisioning or deployment, metadata persistence, and state transitions.
 
 **App**: A user workload deployed from source (git push or Docker image). Built via Nixpacks auto-detection. Runs as a Docker Swarm service.
 
 **Managed service**: Infrastructure PaaStry operates on the user's behalf (Postgres, Redis, etc.). Runs as a Docker Swarm service. May implement `DataServiceManager` or `HAServiceManager`.
 
-**Tenant**: Isolation boundary. Each tenant gets its own Docker overlay network. Services in the same tenant communicate over this network.
+**Tenant**: Isolation boundary. Each tenant gets its own Docker overlay network. The default tenant and its network are created during `paastry init`; additional tenants and networks are created through `CreateTenant`.
 
 **Job**: A long-running async operation (provision, deploy, backup). Returns immediately, executes in a bounded goroutine pool. Composed of structured **steps**, each with its own status and output. Status streamed via `StreamJobStatus` and persisted in SQLite.
 
@@ -41,6 +41,8 @@ The backend is written in Go and orchestrates infrastructure tooling via the Doc
 
 **Control plane**: The PaaStry binary itself — a native Go process that orchestrates Docker containers, persists metadata, and serves the Connect RPC API.
 
+**Host bootstrap**: First-run preparation of the host Docker environment required by PaaStry, including Swarm initialization and default overlay networks. Runs automatically and idempotently before metadata creation during `paastry init`, narrates each host mutation, uses `PAASTRY_SWARM_ADVERTISE_ADDR` when set, must succeed for init to complete, never tears down global Swarm state, and is not self-healed by `paastry server`.
+
 **Stack**: A declarative set of services and their dependencies defined in `paastry.toml`. Deployed and torn down as a unit via `paastry up` / `paastry down`.
 
 **CLI**: Interactive-first command line interface. Commands show structured diffs before mutating, deploy full stacks in dependency order, and support an interactive REPL (`paastry shell`) for exploration and debugging.
@@ -51,6 +53,7 @@ The backend is written in Go and orchestrates infrastructure tooling via the Doc
 - A **Service** may depend on zero or more other **Services**
 - A **Job** targets exactly one **Service**
 - PaaStry **Control plane** runs as a native binary; all **Services** run as Docker containers
+- **Host bootstrap** prepares Docker so **Tenants** can receive overlay networks and **Services** can run in Swarm
 
 ## What PaaStry is NOT
 

--- a/cmd/paastry/run.go
+++ b/cmd/paastry/run.go
@@ -87,14 +87,10 @@ func runServer(ctx context.Context, getenv func(string) string) error {
 	}
 
 	mux := http.NewServeMux()
-	tenantPath, tenantHandler := paastryv1connect.NewTenantServiceHandler(tenantHandler{dbPath: filepath.Join(home, "paastry.db")})
+	tenantPath, tenantHandler := paastryv1connect.NewTenantServiceHandler(tenantHandler{db: db, docker: dc})
 	mux.Handle(tenantPath, tenantHandler)
 	svcPath, svcHandler := paastryv1connect.NewServiceServiceHandler(serviceHandler{
-		db: db,
-		managers: map[paastryv1.ServiceType]service.Manager{
-			paastryv1.ServiceType_SERVICE_TYPE_POSTGRES: service.NewPostgresManager(dc),
-			paastryv1.ServiceType_SERVICE_TYPE_APP:      service.NewAppManager(dc),
-		},
+		lifecycle: service.NewLifecycle(db, dc),
 	})
 	mux.Handle(svcPath, svcHandler)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -141,162 +137,133 @@ func runServer(ctx context.Context, getenv func(string) string) error {
 }
 
 type tenantHandler struct {
-	dbPath string
+	db     *sql.DB
+	docker *docker.Client
 }
 
 func (h tenantHandler) CreateTenant(
-	_ context.Context,
-	_ *connect.Request[paastryv1.CreateTenantRequest],
+	ctx context.Context,
+	req *connect.Request[paastryv1.CreateTenantRequest],
 ) (*connect.Response[paastryv1.CreateTenantResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("create tenant not implemented"))
+	name := req.Msg.Name
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("tenant name is required"))
+	}
+	id := "tenant-" + name
+	networkName := "paastry-" + id
+
+	exists, err := h.docker.NetworkExists(ctx, networkName)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("check network: %w", err))
+	}
+	if !exists {
+		if _, err := h.docker.NetworkCreate(ctx, docker.NetworkCreateSpec{
+			Name:   networkName,
+			Driver: "overlay",
+		}); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create network: %w", err))
+		}
+	}
+
+	_, err = h.db.ExecContext(ctx,
+		`insert into tenants (id, name, network_name) values (?, ?, ?)`,
+		id, name, networkName,
+	)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("insert tenant: %w", err))
+	}
+
+	return connect.NewResponse(&paastryv1.CreateTenantResponse{
+		Tenant: &paastryv1.Tenant{Id: id, Name: name, NetworkName: networkName},
+	}), nil
 }
 
 func (h tenantHandler) GetTenant(
-	_ context.Context,
-	_ *connect.Request[paastryv1.GetTenantRequest],
+	ctx context.Context,
+	req *connect.Request[paastryv1.GetTenantRequest],
 ) (*connect.Response[paastryv1.GetTenantResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("get tenant not implemented"))
+	tenant := &paastryv1.Tenant{}
+	err := h.db.QueryRowContext(ctx,
+		`select id, name, network_name from tenants where id = ?`,
+		req.Msg.TenantId,
+	).Scan(&tenant.Id, &tenant.Name, &tenant.NetworkName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("tenant not found"))
+	}
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get tenant: %w", err))
+	}
+	return connect.NewResponse(&paastryv1.GetTenantResponse{Tenant: tenant}), nil
 }
 
 type serviceHandler struct {
-	db       *sql.DB
-	managers map[paastryv1.ServiceType]service.Manager
-}
-
-func (h serviceHandler) managerFor(typ paastryv1.ServiceType) (service.Manager, error) {
-	m, ok := h.managers[typ]
-	if !ok {
-		return nil, fmt.Errorf("unsupported service type: %v", typ)
-	}
-	return m, nil
+	lifecycle *service.Lifecycle
 }
 
 func (h serviceHandler) ProvisionService(
 	ctx context.Context,
 	req *connect.Request[paastryv1.ProvisionServiceRequest],
 ) (*connect.Response[paastryv1.ProvisionServiceResponse], error) {
-	mgr, err := h.managerFor(req.Msg.Type)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-
-	spec := service.ProvisionSpec{
+	rec, err := h.lifecycle.Provision(ctx, service.ProvisionSpec{
 		Name:       req.Msg.Name,
 		TenantID:   req.Msg.TenantId,
-		Network:    "paastry-tenant-default",
+		Type:       serviceTypeFromProto(req.Msg.Type),
 		Image:      req.Msg.GetImage(),
 		Port:       coercePort(req.Msg.GetPort()),
 		DBName:     "app",
 		DBUser:     "app",
 		DBPassword: "changeme",
+	})
+	if errors.Is(err, service.ErrNotFound) {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("tenant not found"))
 	}
-
-	svc, err := mgr.Provision(ctx, spec)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("provision service: %w", err))
 	}
-
-	_, err = h.db.ExecContext(ctx,
-		`insert into services (id, tenant_id, name, type, state) values (?, ?, ?, ?, ?)`,
-		svc.Id, spec.TenantID, spec.Name, svcTypeDB(req.Msg.Type), svc.State.String(),
-	)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("persist service: %w", err))
-	}
-
-	return connect.NewResponse(&paastryv1.ProvisionServiceResponse{Service: svc}), nil
+	return connect.NewResponse(&paastryv1.ProvisionServiceResponse{Service: serviceRecordToProto(rec)}), nil
 }
 
 func (h serviceHandler) DeployService(
 	ctx context.Context,
 	req *connect.Request[paastryv1.DeployServiceRequest],
 ) (*connect.Response[paastryv1.DeployServiceResponse], error) {
-	mgr, err := h.managerFor(paastryv1.ServiceType_SERVICE_TYPE_APP)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	rec, err := h.lifecycle.Deploy(ctx, req.Msg.ServiceId, req.Msg.Image, coercePort(req.Msg.Port))
+	if errors.Is(err, service.ErrNotFound) {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("service not found"))
 	}
-
-	spec := service.ProvisionSpec{
-		Name:    "",
-		Network: "paastry-tenant-default",
-		Image:   req.Msg.Image,
-		Port:    coercePort(req.Msg.Port),
-	}
-
-	svc, err := mgr.Deploy(ctx, spec, req.Msg.ServiceId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("deploy service: %w", err))
 	}
-
-	return connect.NewResponse(&paastryv1.DeployServiceResponse{Service: svc}), nil
+	return connect.NewResponse(&paastryv1.DeployServiceResponse{Service: serviceRecordToProto(rec)}), nil
 }
 
 func (h serviceHandler) GetService(
 	ctx context.Context,
 	req *connect.Request[paastryv1.GetServiceRequest],
 ) (*connect.Response[paastryv1.GetServiceResponse], error) {
-	svc := &paastryv1.Service{}
-	var typeStr, stateStr string
-	err := h.db.QueryRowContext(ctx,
-		`select id, tenant_id, name, type, state from services where id = ?`,
-		req.Msg.ServiceId,
-	).Scan(&svc.Id, &svc.TenantId, &svc.Name, &typeStr, &stateStr)
-	if errors.Is(err, sql.ErrNoRows) {
+	rec, err := h.lifecycle.Get(ctx, req.Msg.ServiceId)
+	if errors.Is(err, service.ErrNotFound) {
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("service not found"))
 	}
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get service: %w", err))
 	}
-	svc.Type = parseServiceType(typeStr)
-	svc.State = parseServiceState(stateStr)
-	return connect.NewResponse(&paastryv1.GetServiceResponse{Service: svc}), nil
+	return connect.NewResponse(&paastryv1.GetServiceResponse{Service: serviceRecordToProto(rec)}), nil
 }
 
 func (h serviceHandler) ListServices(
 	ctx context.Context,
 	req *connect.Request[paastryv1.ListServicesRequest],
 ) (*connect.Response[paastryv1.ListServicesResponse], error) {
-	rows, err := h.db.QueryContext(ctx,
-		`select id, tenant_id, name, type, state from services where tenant_id = ? order by name`,
-		req.Msg.TenantId,
-	)
+	records, err := h.lifecycle.List(ctx, req.Msg.TenantId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list services: %w", err))
 	}
-	defer rows.Close()
-
-	var services []*paastryv1.Service
-	for rows.Next() {
-		svc := &paastryv1.Service{}
-		var typeStr, stateStr string
-		if err := rows.Scan(&svc.Id, &svc.TenantId, &svc.Name, &typeStr, &stateStr); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scan service: %w", err))
-		}
-		svc.Type = parseServiceType(typeStr)
-		svc.State = parseServiceState(stateStr)
-		services = append(services, svc)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("iterate services: %w", err))
+	services := make([]*paastryv1.Service, 0, len(records))
+	for _, rec := range records {
+		services = append(services, serviceRecordToProto(rec))
 	}
 	return connect.NewResponse(&paastryv1.ListServicesResponse{Services: services}), nil
-}
-
-func svcTypeDB(t paastryv1.ServiceType) string {
-	switch t {
-	case paastryv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
-		return "unspecified"
-	case paastryv1.ServiceType_SERVICE_TYPE_POSTGRES:
-		return "postgres"
-	case paastryv1.ServiceType_SERVICE_TYPE_REDIS:
-		return "redis"
-	case paastryv1.ServiceType_SERVICE_TYPE_VALKEY:
-		return "valkey"
-	case paastryv1.ServiceType_SERVICE_TYPE_APP:
-		return "app"
-	default:
-		return "unspecified"
-	}
 }
 
 func coercePort(p int32) uint32 {
@@ -306,31 +273,48 @@ func coercePort(p int32) uint32 {
 	return uint32(p)
 }
 
-func parseServiceType(s string) paastryv1.ServiceType {
-	switch s {
-	case "postgres":
+func serviceTypeFromProto(t paastryv1.ServiceType) service.Type {
+	switch t {
+	case paastryv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
+		return ""
+	case paastryv1.ServiceType_SERVICE_TYPE_POSTGRES:
+		return service.TypePostgres
+	case paastryv1.ServiceType_SERVICE_TYPE_REDIS:
+		return ""
+	case paastryv1.ServiceType_SERVICE_TYPE_VALKEY:
+		return ""
+	case paastryv1.ServiceType_SERVICE_TYPE_APP:
+		return service.TypeApp
+	default:
+		return ""
+	}
+}
+
+func serviceRecordToProto(rec *service.Record) *paastryv1.Service {
+	return &paastryv1.Service{
+		Id:       rec.ID,
+		TenantId: rec.TenantID,
+		Name:     rec.Name,
+		Type:     serviceTypeToProto(rec.Type),
+		State:    serviceStateToProto(rec.State),
+	}
+}
+
+func serviceTypeToProto(t service.Type) paastryv1.ServiceType {
+	switch t {
+	case service.TypePostgres:
 		return paastryv1.ServiceType_SERVICE_TYPE_POSTGRES
-	case "redis":
-		return paastryv1.ServiceType_SERVICE_TYPE_REDIS
-	case "valkey":
-		return paastryv1.ServiceType_SERVICE_TYPE_VALKEY
-	case "app":
+	case service.TypeApp:
 		return paastryv1.ServiceType_SERVICE_TYPE_APP
 	default:
 		return paastryv1.ServiceType_SERVICE_TYPE_UNSPECIFIED
 	}
 }
 
-func parseServiceState(s string) paastryv1.ServiceState {
+func serviceStateToProto(s service.State) paastryv1.ServiceState {
 	switch s {
-	case "provisioning":
-		return paastryv1.ServiceState_SERVICE_STATE_PROVISIONING
-	case "running":
+	case service.StateRunning:
 		return paastryv1.ServiceState_SERVICE_STATE_RUNNING
-	case "failed":
-		return paastryv1.ServiceState_SERVICE_STATE_FAILED
-	case "deprovisioned":
-		return paastryv1.ServiceState_SERVICE_STATE_DEPROVISIONED
 	default:
 		return paastryv1.ServiceState_SERVICE_STATE_UNSPECIFIED
 	}
@@ -340,13 +324,7 @@ func (h tenantHandler) ListTenants(
 	ctx context.Context,
 	_ *connect.Request[paastryv1.ListTenantsRequest],
 ) (*connect.Response[paastryv1.ListTenantsResponse], error) {
-	db, err := sql.Open("sqlite", h.dbPath)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("open sqlite database: %w", err))
-	}
-	defer db.Close()
-
-	rows, err := db.QueryContext(ctx, `select id, name, network_name from tenants order by name`)
+	rows, err := h.db.QueryContext(ctx, `select id, name, network_name from tenants order by name`)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list tenants: %w", err))
 	}

--- a/cmd/paastry/run.go
+++ b/cmd/paastry/run.go
@@ -90,8 +90,11 @@ func runServer(ctx context.Context, getenv func(string) string) error {
 	tenantPath, tenantHandler := paastryv1connect.NewTenantServiceHandler(tenantHandler{dbPath: filepath.Join(home, "paastry.db")})
 	mux.Handle(tenantPath, tenantHandler)
 	svcPath, svcHandler := paastryv1connect.NewServiceServiceHandler(serviceHandler{
-		db:      db,
-		manager: service.NewPostgresManager(dc),
+		db: db,
+		managers: map[paastryv1.ServiceType]service.Manager{
+			paastryv1.ServiceType_SERVICE_TYPE_POSTGRES: service.NewPostgresManager(dc),
+			paastryv1.ServiceType_SERVICE_TYPE_APP:      service.NewAppManager(dc),
+		},
 	})
 	mux.Handle(svcPath, svcHandler)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -156,37 +159,76 @@ func (h tenantHandler) GetTenant(
 }
 
 type serviceHandler struct {
-	db      *sql.DB
-	manager service.Manager
+	db       *sql.DB
+	managers map[paastryv1.ServiceType]service.Manager
+}
+
+func (h serviceHandler) managerFor(typ paastryv1.ServiceType) (service.Manager, error) {
+	m, ok := h.managers[typ]
+	if !ok {
+		return nil, fmt.Errorf("unsupported service type: %v", typ)
+	}
+	return m, nil
 }
 
 func (h serviceHandler) ProvisionService(
 	ctx context.Context,
 	req *connect.Request[paastryv1.ProvisionServiceRequest],
 ) (*connect.Response[paastryv1.ProvisionServiceResponse], error) {
+	mgr, err := h.managerFor(req.Msg.Type)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
 	spec := service.ProvisionSpec{
 		Name:       req.Msg.Name,
 		TenantID:   req.Msg.TenantId,
 		Network:    "paastry-tenant-default",
+		Image:      req.Msg.GetImage(),
+		Port:       coercePort(req.Msg.GetPort()),
 		DBName:     "app",
 		DBUser:     "app",
 		DBPassword: "changeme",
 	}
 
-	svc, err := h.manager.Provision(ctx, spec)
+	svc, err := mgr.Provision(ctx, spec)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("provision service: %w", err))
 	}
 
 	_, err = h.db.ExecContext(ctx,
 		`insert into services (id, tenant_id, name, type, state) values (?, ?, ?, ?, ?)`,
-		svc.Id, spec.TenantID, spec.Name, "postgres", svc.State.String(),
+		svc.Id, spec.TenantID, spec.Name, svcTypeDB(req.Msg.Type), svc.State.String(),
 	)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("persist service: %w", err))
 	}
 
 	return connect.NewResponse(&paastryv1.ProvisionServiceResponse{Service: svc}), nil
+}
+
+func (h serviceHandler) DeployService(
+	ctx context.Context,
+	req *connect.Request[paastryv1.DeployServiceRequest],
+) (*connect.Response[paastryv1.DeployServiceResponse], error) {
+	mgr, err := h.managerFor(paastryv1.ServiceType_SERVICE_TYPE_APP)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	spec := service.ProvisionSpec{
+		Name:    "",
+		Network: "paastry-tenant-default",
+		Image:   req.Msg.Image,
+		Port:    coercePort(req.Msg.Port),
+	}
+
+	svc, err := mgr.Deploy(ctx, spec, req.Msg.ServiceId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("deploy service: %w", err))
+	}
+
+	return connect.NewResponse(&paastryv1.DeployServiceResponse{Service: svc}), nil
 }
 
 func (h serviceHandler) GetService(
@@ -240,6 +282,30 @@ func (h serviceHandler) ListServices(
 	return connect.NewResponse(&paastryv1.ListServicesResponse{Services: services}), nil
 }
 
+func svcTypeDB(t paastryv1.ServiceType) string {
+	switch t {
+	case paastryv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
+		return "unspecified"
+	case paastryv1.ServiceType_SERVICE_TYPE_POSTGRES:
+		return "postgres"
+	case paastryv1.ServiceType_SERVICE_TYPE_REDIS:
+		return "redis"
+	case paastryv1.ServiceType_SERVICE_TYPE_VALKEY:
+		return "valkey"
+	case paastryv1.ServiceType_SERVICE_TYPE_APP:
+		return "app"
+	default:
+		return "unspecified"
+	}
+}
+
+func coercePort(p int32) uint32 {
+	if p < 1 || p > 65535 {
+		return 0
+	}
+	return uint32(p)
+}
+
 func parseServiceType(s string) paastryv1.ServiceType {
 	switch s {
 	case "postgres":
@@ -248,6 +314,8 @@ func parseServiceType(s string) paastryv1.ServiceType {
 		return paastryv1.ServiceType_SERVICE_TYPE_REDIS
 	case "valkey":
 		return paastryv1.ServiceType_SERVICE_TYPE_VALKEY
+	case "app":
+		return paastryv1.ServiceType_SERVICE_TYPE_APP
 	default:
 		return paastryv1.ServiceType_SERVICE_TYPE_UNSPECIFIED
 	}

--- a/docs/adr/0004-automatic-host-bootstrap-during-init.md
+++ b/docs/adr/0004-automatic-host-bootstrap-during-init.md
@@ -1,0 +1,3 @@
+# Automatic host bootstrap during init
+
+PaaStry runs Docker host bootstrap automatically during `paastry init`: it initializes Swarm when needed, creates the default tenant overlay network, narrates each host mutation, and fails init if Docker cannot be prepared. This chooses self-hosted PaaS convenience over a stricter operator-prepared-host model while keeping host mutation confined to init rather than `paastry server`.

--- a/gen/paastry/v1/paastryv1connect/services.connect.go
+++ b/gen/paastry/v1/paastryv1connect/services.connect.go
@@ -36,6 +36,9 @@ const (
 	// ServiceServiceProvisionServiceProcedure is the fully-qualified name of the ServiceService's
 	// ProvisionService RPC.
 	ServiceServiceProvisionServiceProcedure = "/paastry.v1.ServiceService/ProvisionService"
+	// ServiceServiceDeployServiceProcedure is the fully-qualified name of the ServiceService's
+	// DeployService RPC.
+	ServiceServiceDeployServiceProcedure = "/paastry.v1.ServiceService/DeployService"
 	// ServiceServiceGetServiceProcedure is the fully-qualified name of the ServiceService's GetService
 	// RPC.
 	ServiceServiceGetServiceProcedure = "/paastry.v1.ServiceService/GetService"
@@ -47,6 +50,7 @@ const (
 // ServiceServiceClient is a client for the paastry.v1.ServiceService service.
 type ServiceServiceClient interface {
 	ProvisionService(context.Context, *connect.Request[v1.ProvisionServiceRequest]) (*connect.Response[v1.ProvisionServiceResponse], error)
+	DeployService(context.Context, *connect.Request[v1.DeployServiceRequest]) (*connect.Response[v1.DeployServiceResponse], error)
 	GetService(context.Context, *connect.Request[v1.GetServiceRequest]) (*connect.Response[v1.GetServiceResponse], error)
 	ListServices(context.Context, *connect.Request[v1.ListServicesRequest]) (*connect.Response[v1.ListServicesResponse], error)
 }
@@ -68,6 +72,12 @@ func NewServiceServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(serviceServiceMethods.ByName("ProvisionService")),
 			connect.WithClientOptions(opts...),
 		),
+		deployService: connect.NewClient[v1.DeployServiceRequest, v1.DeployServiceResponse](
+			httpClient,
+			baseURL+ServiceServiceDeployServiceProcedure,
+			connect.WithSchema(serviceServiceMethods.ByName("DeployService")),
+			connect.WithClientOptions(opts...),
+		),
 		getService: connect.NewClient[v1.GetServiceRequest, v1.GetServiceResponse](
 			httpClient,
 			baseURL+ServiceServiceGetServiceProcedure,
@@ -86,6 +96,7 @@ func NewServiceServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 // serviceServiceClient implements ServiceServiceClient.
 type serviceServiceClient struct {
 	provisionService *connect.Client[v1.ProvisionServiceRequest, v1.ProvisionServiceResponse]
+	deployService    *connect.Client[v1.DeployServiceRequest, v1.DeployServiceResponse]
 	getService       *connect.Client[v1.GetServiceRequest, v1.GetServiceResponse]
 	listServices     *connect.Client[v1.ListServicesRequest, v1.ListServicesResponse]
 }
@@ -93,6 +104,11 @@ type serviceServiceClient struct {
 // ProvisionService calls paastry.v1.ServiceService.ProvisionService.
 func (c *serviceServiceClient) ProvisionService(ctx context.Context, req *connect.Request[v1.ProvisionServiceRequest]) (*connect.Response[v1.ProvisionServiceResponse], error) {
 	return c.provisionService.CallUnary(ctx, req)
+}
+
+// DeployService calls paastry.v1.ServiceService.DeployService.
+func (c *serviceServiceClient) DeployService(ctx context.Context, req *connect.Request[v1.DeployServiceRequest]) (*connect.Response[v1.DeployServiceResponse], error) {
+	return c.deployService.CallUnary(ctx, req)
 }
 
 // GetService calls paastry.v1.ServiceService.GetService.
@@ -108,6 +124,7 @@ func (c *serviceServiceClient) ListServices(ctx context.Context, req *connect.Re
 // ServiceServiceHandler is an implementation of the paastry.v1.ServiceService service.
 type ServiceServiceHandler interface {
 	ProvisionService(context.Context, *connect.Request[v1.ProvisionServiceRequest]) (*connect.Response[v1.ProvisionServiceResponse], error)
+	DeployService(context.Context, *connect.Request[v1.DeployServiceRequest]) (*connect.Response[v1.DeployServiceResponse], error)
 	GetService(context.Context, *connect.Request[v1.GetServiceRequest]) (*connect.Response[v1.GetServiceResponse], error)
 	ListServices(context.Context, *connect.Request[v1.ListServicesRequest]) (*connect.Response[v1.ListServicesResponse], error)
 }
@@ -123,6 +140,12 @@ func NewServiceServiceHandler(svc ServiceServiceHandler, opts ...connect.Handler
 		ServiceServiceProvisionServiceProcedure,
 		svc.ProvisionService,
 		connect.WithSchema(serviceServiceMethods.ByName("ProvisionService")),
+		connect.WithHandlerOptions(opts...),
+	)
+	serviceServiceDeployServiceHandler := connect.NewUnaryHandler(
+		ServiceServiceDeployServiceProcedure,
+		svc.DeployService,
+		connect.WithSchema(serviceServiceMethods.ByName("DeployService")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceServiceGetServiceHandler := connect.NewUnaryHandler(
@@ -141,6 +164,8 @@ func NewServiceServiceHandler(svc ServiceServiceHandler, opts ...connect.Handler
 		switch r.URL.Path {
 		case ServiceServiceProvisionServiceProcedure:
 			serviceServiceProvisionServiceHandler.ServeHTTP(w, r)
+		case ServiceServiceDeployServiceProcedure:
+			serviceServiceDeployServiceHandler.ServeHTTP(w, r)
 		case ServiceServiceGetServiceProcedure:
 			serviceServiceGetServiceHandler.ServeHTTP(w, r)
 		case ServiceServiceListServicesProcedure:
@@ -156,6 +181,10 @@ type UnimplementedServiceServiceHandler struct{}
 
 func (UnimplementedServiceServiceHandler) ProvisionService(context.Context, *connect.Request[v1.ProvisionServiceRequest]) (*connect.Response[v1.ProvisionServiceResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("paastry.v1.ServiceService.ProvisionService is not implemented"))
+}
+
+func (UnimplementedServiceServiceHandler) DeployService(context.Context, *connect.Request[v1.DeployServiceRequest]) (*connect.Response[v1.DeployServiceResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("paastry.v1.ServiceService.DeployService is not implemented"))
 }
 
 func (UnimplementedServiceServiceHandler) GetService(context.Context, *connect.Request[v1.GetServiceRequest]) (*connect.Response[v1.GetServiceResponse], error) {

--- a/gen/paastry/v1/services.pb.go
+++ b/gen/paastry/v1/services.pb.go
@@ -29,6 +29,7 @@ const (
 	ServiceType_SERVICE_TYPE_POSTGRES    ServiceType = 1
 	ServiceType_SERVICE_TYPE_REDIS       ServiceType = 2
 	ServiceType_SERVICE_TYPE_VALKEY      ServiceType = 3
+	ServiceType_SERVICE_TYPE_APP         ServiceType = 4
 )
 
 // Enum value maps for ServiceType.
@@ -38,12 +39,14 @@ var (
 		1: "SERVICE_TYPE_POSTGRES",
 		2: "SERVICE_TYPE_REDIS",
 		3: "SERVICE_TYPE_VALKEY",
+		4: "SERVICE_TYPE_APP",
 	}
 	ServiceType_value = map[string]int32{
 		"SERVICE_TYPE_UNSPECIFIED": 0,
 		"SERVICE_TYPE_POSTGRES":    1,
 		"SERVICE_TYPE_REDIS":       2,
 		"SERVICE_TYPE_VALKEY":      3,
+		"SERVICE_TYPE_APP":         4,
 	}
 )
 
@@ -218,6 +221,8 @@ type ProvisionServiceRequest struct {
 	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	Type          ServiceType            `protobuf:"varint,3,opt,name=type,proto3,enum=paastry.v1.ServiceType" json:"type,omitempty"`
+	Image         string                 `protobuf:"bytes,4,opt,name=image,proto3" json:"image,omitempty"`
+	Port          int32                  `protobuf:"varint,5,opt,name=port,proto3" json:"port,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -271,6 +276,20 @@ func (x *ProvisionServiceRequest) GetType() ServiceType {
 		return x.Type
 	}
 	return ServiceType_SERVICE_TYPE_UNSPECIFIED
+}
+
+func (x *ProvisionServiceRequest) GetImage() string {
+	if x != nil {
+		return x.Image
+	}
+	return ""
+}
+
+func (x *ProvisionServiceRequest) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
 }
 
 type ProvisionServiceResponse struct {
@@ -449,6 +468,110 @@ func (x *ListServicesRequest) GetTenantId() string {
 	return ""
 }
 
+type DeployServiceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ServiceId     string                 `protobuf:"bytes,1,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
+	Image         string                 `protobuf:"bytes,2,opt,name=image,proto3" json:"image,omitempty"`
+	Port          int32                  `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeployServiceRequest) Reset() {
+	*x = DeployServiceRequest{}
+	mi := &file_paastry_v1_services_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeployServiceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeployServiceRequest) ProtoMessage() {}
+
+func (x *DeployServiceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_paastry_v1_services_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeployServiceRequest.ProtoReflect.Descriptor instead.
+func (*DeployServiceRequest) Descriptor() ([]byte, []int) {
+	return file_paastry_v1_services_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *DeployServiceRequest) GetServiceId() string {
+	if x != nil {
+		return x.ServiceId
+	}
+	return ""
+}
+
+func (x *DeployServiceRequest) GetImage() string {
+	if x != nil {
+		return x.Image
+	}
+	return ""
+}
+
+func (x *DeployServiceRequest) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+type DeployServiceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Service       *Service               `protobuf:"bytes,1,opt,name=service,proto3" json:"service,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeployServiceResponse) Reset() {
+	*x = DeployServiceResponse{}
+	mi := &file_paastry_v1_services_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeployServiceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeployServiceResponse) ProtoMessage() {}
+
+func (x *DeployServiceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_paastry_v1_services_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeployServiceResponse.ProtoReflect.Descriptor instead.
+func (*DeployServiceResponse) Descriptor() ([]byte, []int) {
+	return file_paastry_v1_services_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *DeployServiceResponse) GetService() *Service {
+	if x != nil {
+		return x.Service
+	}
+	return nil
+}
+
 type ListServicesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Services      []*Service             `protobuf:"bytes,1,rep,name=services,proto3" json:"services,omitempty"`
@@ -458,7 +581,7 @@ type ListServicesResponse struct {
 
 func (x *ListServicesResponse) Reset() {
 	*x = ListServicesResponse{}
-	mi := &file_paastry_v1_services_proto_msgTypes[6]
+	mi := &file_paastry_v1_services_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -470,7 +593,7 @@ func (x *ListServicesResponse) String() string {
 func (*ListServicesResponse) ProtoMessage() {}
 
 func (x *ListServicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_paastry_v1_services_proto_msgTypes[6]
+	mi := &file_paastry_v1_services_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -483,7 +606,7 @@ func (x *ListServicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListServicesResponse.ProtoReflect.Descriptor instead.
 func (*ListServicesResponse) Descriptor() ([]byte, []int) {
-	return file_paastry_v1_services_proto_rawDescGZIP(), []int{6}
+	return file_paastry_v1_services_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListServicesResponse) GetServices() []*Service {
@@ -506,11 +629,13 @@ const file_paastry_v1_services_proto_rawDesc = "" +
 	"\x04type\x18\x04 \x01(\x0e2\x17.paastry.v1.ServiceTypeR\x04type\x12.\n" +
 	"\x05state\x18\x05 \x01(\x0e2\x18.paastry.v1.ServiceStateR\x05state\x129\n" +
 	"\n" +
-	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"w\n" +
+	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xa1\x01\n" +
 	"\x17ProvisionServiceRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12+\n" +
-	"\x04type\x18\x03 \x01(\x0e2\x17.paastry.v1.ServiceTypeR\x04type\"I\n" +
+	"\x04type\x18\x03 \x01(\x0e2\x17.paastry.v1.ServiceTypeR\x04type\x12\x14\n" +
+	"\x05image\x18\x04 \x01(\tR\x05image\x12\x12\n" +
+	"\x04port\x18\x05 \x01(\x05R\x04port\"I\n" +
 	"\x18ProvisionServiceResponse\x12-\n" +
 	"\aservice\x18\x01 \x01(\v2\x13.paastry.v1.ServiceR\aservice\"2\n" +
 	"\x11GetServiceRequest\x12\x1d\n" +
@@ -519,22 +644,31 @@ const file_paastry_v1_services_proto_rawDesc = "" +
 	"\x12GetServiceResponse\x12-\n" +
 	"\aservice\x18\x01 \x01(\v2\x13.paastry.v1.ServiceR\aservice\"2\n" +
 	"\x13ListServicesRequest\x12\x1b\n" +
-	"\ttenant_id\x18\x01 \x01(\tR\btenantId\"G\n" +
+	"\ttenant_id\x18\x01 \x01(\tR\btenantId\"_\n" +
+	"\x14DeployServiceRequest\x12\x1d\n" +
+	"\n" +
+	"service_id\x18\x01 \x01(\tR\tserviceId\x12\x14\n" +
+	"\x05image\x18\x02 \x01(\tR\x05image\x12\x12\n" +
+	"\x04port\x18\x03 \x01(\x05R\x04port\"F\n" +
+	"\x15DeployServiceResponse\x12-\n" +
+	"\aservice\x18\x01 \x01(\v2\x13.paastry.v1.ServiceR\aservice\"G\n" +
 	"\x14ListServicesResponse\x12/\n" +
-	"\bservices\x18\x01 \x03(\v2\x13.paastry.v1.ServiceR\bservices*w\n" +
+	"\bservices\x18\x01 \x03(\v2\x13.paastry.v1.ServiceR\bservices*\x8d\x01\n" +
 	"\vServiceType\x12\x1c\n" +
 	"\x18SERVICE_TYPE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SERVICE_TYPE_POSTGRES\x10\x01\x12\x16\n" +
 	"\x12SERVICE_TYPE_REDIS\x10\x02\x12\x17\n" +
-	"\x13SERVICE_TYPE_VALKEY\x10\x03*\xa3\x01\n" +
+	"\x13SERVICE_TYPE_VALKEY\x10\x03\x12\x14\n" +
+	"\x10SERVICE_TYPE_APP\x10\x04*\xa3\x01\n" +
 	"\fServiceState\x12\x1d\n" +
 	"\x19SERVICE_STATE_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aSERVICE_STATE_PROVISIONING\x10\x01\x12\x19\n" +
 	"\x15SERVICE_STATE_RUNNING\x10\x02\x12\x18\n" +
 	"\x14SERVICE_STATE_FAILED\x10\x03\x12\x1f\n" +
-	"\x1bSERVICE_STATE_DEPROVISIONED\x10\x042\x8f\x02\n" +
+	"\x1bSERVICE_STATE_DEPROVISIONED\x10\x042\xe5\x02\n" +
 	"\x0eServiceService\x12]\n" +
-	"\x10ProvisionService\x12#.paastry.v1.ProvisionServiceRequest\x1a$.paastry.v1.ProvisionServiceResponse\x12K\n" +
+	"\x10ProvisionService\x12#.paastry.v1.ProvisionServiceRequest\x1a$.paastry.v1.ProvisionServiceResponse\x12T\n" +
+	"\rDeployService\x12 .paastry.v1.DeployServiceRequest\x1a!.paastry.v1.DeployServiceResponse\x12K\n" +
 	"\n" +
 	"GetService\x12\x1d.paastry.v1.GetServiceRequest\x1a\x1e.paastry.v1.GetServiceResponse\x12Q\n" +
 	"\fListServices\x12\x1f.paastry.v1.ListServicesRequest\x1a .paastry.v1.ListServicesResponseB:Z8github.com/LoriKarikari/paastry/gen/paastry/v1;paastryv1b\x06proto3"
@@ -552,7 +686,7 @@ func file_paastry_v1_services_proto_rawDescGZIP() []byte {
 }
 
 var file_paastry_v1_services_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_paastry_v1_services_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_paastry_v1_services_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_paastry_v1_services_proto_goTypes = []any{
 	(ServiceType)(0),                 // 0: paastry.v1.ServiceType
 	(ServiceState)(0),                // 1: paastry.v1.ServiceState
@@ -562,28 +696,33 @@ var file_paastry_v1_services_proto_goTypes = []any{
 	(*GetServiceRequest)(nil),        // 5: paastry.v1.GetServiceRequest
 	(*GetServiceResponse)(nil),       // 6: paastry.v1.GetServiceResponse
 	(*ListServicesRequest)(nil),      // 7: paastry.v1.ListServicesRequest
-	(*ListServicesResponse)(nil),     // 8: paastry.v1.ListServicesResponse
-	(*timestamppb.Timestamp)(nil),    // 9: google.protobuf.Timestamp
+	(*DeployServiceRequest)(nil),     // 8: paastry.v1.DeployServiceRequest
+	(*DeployServiceResponse)(nil),    // 9: paastry.v1.DeployServiceResponse
+	(*ListServicesResponse)(nil),     // 10: paastry.v1.ListServicesResponse
+	(*timestamppb.Timestamp)(nil),    // 11: google.protobuf.Timestamp
 }
 var file_paastry_v1_services_proto_depIdxs = []int32{
 	0,  // 0: paastry.v1.Service.type:type_name -> paastry.v1.ServiceType
 	1,  // 1: paastry.v1.Service.state:type_name -> paastry.v1.ServiceState
-	9,  // 2: paastry.v1.Service.created_at:type_name -> google.protobuf.Timestamp
+	11, // 2: paastry.v1.Service.created_at:type_name -> google.protobuf.Timestamp
 	0,  // 3: paastry.v1.ProvisionServiceRequest.type:type_name -> paastry.v1.ServiceType
 	2,  // 4: paastry.v1.ProvisionServiceResponse.service:type_name -> paastry.v1.Service
 	2,  // 5: paastry.v1.GetServiceResponse.service:type_name -> paastry.v1.Service
-	2,  // 6: paastry.v1.ListServicesResponse.services:type_name -> paastry.v1.Service
-	3,  // 7: paastry.v1.ServiceService.ProvisionService:input_type -> paastry.v1.ProvisionServiceRequest
-	5,  // 8: paastry.v1.ServiceService.GetService:input_type -> paastry.v1.GetServiceRequest
-	7,  // 9: paastry.v1.ServiceService.ListServices:input_type -> paastry.v1.ListServicesRequest
-	4,  // 10: paastry.v1.ServiceService.ProvisionService:output_type -> paastry.v1.ProvisionServiceResponse
-	6,  // 11: paastry.v1.ServiceService.GetService:output_type -> paastry.v1.GetServiceResponse
-	8,  // 12: paastry.v1.ServiceService.ListServices:output_type -> paastry.v1.ListServicesResponse
-	10, // [10:13] is the sub-list for method output_type
-	7,  // [7:10] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	2,  // 6: paastry.v1.DeployServiceResponse.service:type_name -> paastry.v1.Service
+	2,  // 7: paastry.v1.ListServicesResponse.services:type_name -> paastry.v1.Service
+	3,  // 8: paastry.v1.ServiceService.ProvisionService:input_type -> paastry.v1.ProvisionServiceRequest
+	8,  // 9: paastry.v1.ServiceService.DeployService:input_type -> paastry.v1.DeployServiceRequest
+	5,  // 10: paastry.v1.ServiceService.GetService:input_type -> paastry.v1.GetServiceRequest
+	7,  // 11: paastry.v1.ServiceService.ListServices:input_type -> paastry.v1.ListServicesRequest
+	4,  // 12: paastry.v1.ServiceService.ProvisionService:output_type -> paastry.v1.ProvisionServiceResponse
+	9,  // 13: paastry.v1.ServiceService.DeployService:output_type -> paastry.v1.DeployServiceResponse
+	6,  // 14: paastry.v1.ServiceService.GetService:output_type -> paastry.v1.GetServiceResponse
+	10, // 15: paastry.v1.ServiceService.ListServices:output_type -> paastry.v1.ListServicesResponse
+	12, // [12:16] is the sub-list for method output_type
+	8,  // [8:12] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_paastry_v1_services_proto_init() }
@@ -597,7 +736,7 @@ func file_paastry_v1_services_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_paastry_v1_services_proto_rawDesc), len(file_paastry_v1_services_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -55,14 +55,16 @@ func New() (*Client, error) {
 }
 
 func (c *Client) NetworkCreate(ctx context.Context, spec NetworkCreateSpec) (*Network, error) {
-	resp, err := c.inner.NetworkCreate(ctx, spec.Name, client.NetworkCreateOptions{
-		Driver: spec.Driver,
-		IPAM: &network.IPAM{
+	opts := client.NetworkCreateOptions{Driver: spec.Driver}
+	if spec.Subnet.IsValid() || spec.Gateway.IsValid() {
+		opts.IPAM = &network.IPAM{
 			Config: []network.IPAMConfig{
 				{Subnet: spec.Subnet, Gateway: spec.Gateway},
 			},
-		},
-	})
+		}
+	}
+
+	resp, err := c.inner.NetworkCreate(ctx, spec.Name, opts)
 	if err != nil {
 		return nil, fmt.Errorf("network create: %w", err)
 	}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -38,6 +38,7 @@ type ServiceCreateSpec struct {
 	Env     []string
 	Network string
 	Mounts  []Mount
+	Port    uint32
 }
 
 type Service struct {
@@ -116,12 +117,24 @@ func (c *Client) ServiceCreate(ctx context.Context, spec ServiceCreateSpec) (*Se
 		task.Networks = []swarm.NetworkAttachmentConfig{{Target: spec.Network}}
 	}
 
-	resp, err := c.inner.ServiceCreate(ctx, client.ServiceCreateOptions{
-		Spec: swarm.ServiceSpec{
-			Annotations:  swarm.Annotations{Name: spec.Name},
-			TaskTemplate: task,
-		},
-	})
+	svcSpec := swarm.ServiceSpec{
+		Annotations:  swarm.Annotations{Name: spec.Name},
+		TaskTemplate: task,
+	}
+	if spec.Port > 0 {
+		svcSpec.EndpointSpec = &swarm.EndpointSpec{
+			Ports: []swarm.PortConfig{
+				{
+					Protocol:      network.TCP,
+					TargetPort:    spec.Port,
+					PublishedPort: 0,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+			},
+		}
+	}
+
+	resp, err := c.inner.ServiceCreate(ctx, client.ServiceCreateOptions{Spec: svcSpec})
 	if err != nil {
 		return nil, fmt.Errorf("service create: %w", err)
 	}

--- a/internal/service/app.go
+++ b/internal/service/app.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	paastryv1 "github.com/LoriKarikari/paastry/gen/paastry/v1"
+	"github.com/LoriKarikari/paastry/internal/docker"
+	"github.com/google/uuid"
+)
+
+type appManager struct {
+	docker DockerClient
+}
+
+func NewAppManager(docker DockerClient) Manager {
+	return &appManager{docker: docker}
+}
+
+func (m *appManager) Provision(ctx context.Context, spec ProvisionSpec) (*paastryv1.Service, error) {
+	id := uuid.NewString()
+	svcName := "paastry-app-" + spec.Name
+
+	_, err := m.docker.ServiceCreate(ctx, docker.ServiceCreateSpec{
+		Name:    svcName,
+		Image:   spec.Image,
+		Network: spec.Network,
+		Port:    spec.Port,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create app service: %w", err)
+	}
+
+	return &paastryv1.Service{
+		Id:    id,
+		Name:  spec.Name,
+		Type:  paastryv1.ServiceType_SERVICE_TYPE_APP,
+		State: paastryv1.ServiceState_SERVICE_STATE_RUNNING,
+	}, nil
+}
+
+func (m *appManager) Deploy(ctx context.Context, spec ProvisionSpec, serviceID string) (*paastryv1.Service, error) {
+	svcName := "paastry-app-" + spec.Name
+
+	_, err := m.docker.ServiceCreate(ctx, docker.ServiceCreateSpec{
+		Name:    svcName,
+		Image:   spec.Image,
+		Network: spec.Network,
+		Port:    spec.Port,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("deploy app service: %w", err)
+	}
+
+	return &paastryv1.Service{
+		Id:    serviceID,
+		Name:  spec.Name,
+		Type:  paastryv1.ServiceType_SERVICE_TYPE_APP,
+		State: paastryv1.ServiceState_SERVICE_STATE_RUNNING,
+	}, nil
+}

--- a/internal/service/app.go
+++ b/internal/service/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	paastryv1 "github.com/LoriKarikari/paastry/gen/paastry/v1"
 	"github.com/LoriKarikari/paastry/internal/docker"
 	"github.com/google/uuid"
 )
@@ -13,11 +12,11 @@ type appManager struct {
 	docker DockerClient
 }
 
-func NewAppManager(docker DockerClient) Manager {
+func newAppManager(docker DockerClient) manager {
 	return &appManager{docker: docker}
 }
 
-func (m *appManager) Provision(ctx context.Context, spec ProvisionSpec) (*paastryv1.Service, error) {
+func (m *appManager) Provision(ctx context.Context, spec provisionerSpec) (*Record, error) {
 	id := uuid.NewString()
 	svcName := "paastry-app-" + spec.Name
 
@@ -31,15 +30,16 @@ func (m *appManager) Provision(ctx context.Context, spec ProvisionSpec) (*paastr
 		return nil, fmt.Errorf("create app service: %w", err)
 	}
 
-	return &paastryv1.Service{
-		Id:    id,
-		Name:  spec.Name,
-		Type:  paastryv1.ServiceType_SERVICE_TYPE_APP,
-		State: paastryv1.ServiceState_SERVICE_STATE_RUNNING,
+	return &Record{
+		ID:       id,
+		TenantID: spec.TenantID,
+		Name:     spec.Name,
+		Type:     TypeApp,
+		State:    StateRunning,
 	}, nil
 }
 
-func (m *appManager) Deploy(ctx context.Context, spec ProvisionSpec, serviceID string) (*paastryv1.Service, error) {
+func (m *appManager) Deploy(ctx context.Context, spec provisionerSpec, serviceID string) (*Record, error) {
 	svcName := "paastry-app-" + spec.Name
 
 	_, err := m.docker.ServiceCreate(ctx, docker.ServiceCreateSpec{
@@ -52,10 +52,11 @@ func (m *appManager) Deploy(ctx context.Context, spec ProvisionSpec, serviceID s
 		return nil, fmt.Errorf("deploy app service: %w", err)
 	}
 
-	return &paastryv1.Service{
-		Id:    serviceID,
-		Name:  spec.Name,
-		Type:  paastryv1.ServiceType_SERVICE_TYPE_APP,
-		State: paastryv1.ServiceState_SERVICE_STATE_RUNNING,
+	return &Record{
+		ID:       serviceID,
+		TenantID: spec.TenantID,
+		Name:     spec.Name,
+		Type:     TypeApp,
+		State:    StateRunning,
 	}, nil
 }

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+var ErrNotFound = errors.New("not found")
+
+func (l *Lifecycle) Provision(ctx context.Context, spec ProvisionSpec) (*Record, error) {
+	mgr, ok := l.managers[spec.Type]
+	if !ok {
+		return nil, fmt.Errorf("unsupported service type: %s", spec.Type)
+	}
+
+	var networkName string
+	if err := l.db.QueryRowContext(ctx,
+		`select network_name from tenants where id = ?`, spec.TenantID,
+	).Scan(&networkName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("lookup tenant: %w", err)
+	}
+
+	rec, err := mgr.Provision(ctx, provisionerSpec{
+		Name:       spec.Name,
+		TenantID:   spec.TenantID,
+		Network:    networkName,
+		Image:      spec.Image,
+		Port:       spec.Port,
+		DBName:     spec.DBName,
+		DBUser:     spec.DBUser,
+		DBPassword: spec.DBPassword,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("provision service: %w", err)
+	}
+
+	_, err = l.db.ExecContext(ctx,
+		`insert into services (id, tenant_id, name, type, state) values (?, ?, ?, ?, ?)`,
+		rec.ID, rec.TenantID, rec.Name, string(rec.Type), string(rec.State),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("persist service: %w", err)
+	}
+	return rec, nil
+}
+
+func (l *Lifecycle) Deploy(ctx context.Context, serviceID string, image string, port uint32) (*Record, error) {
+	rec, networkName, err := l.getWithNetwork(ctx, serviceID)
+	if err != nil {
+		return nil, err
+	}
+	mgr, ok := l.managers[rec.Type]
+	if !ok {
+		return nil, fmt.Errorf("unsupported service type: %s", rec.Type)
+	}
+	deployed, err := mgr.Deploy(ctx, provisionerSpec{
+		Name:     rec.Name,
+		TenantID: rec.TenantID,
+		Network:  networkName,
+		Image:    image,
+		Port:     port,
+	}, serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("deploy service: %w", err)
+	}
+	return deployed, nil
+}
+
+func (l *Lifecycle) Get(ctx context.Context, serviceID string) (*Record, error) {
+	rec, _, err := l.getWithNetwork(ctx, serviceID)
+	return rec, err
+}
+
+func (l *Lifecycle) List(ctx context.Context, tenantID string) ([]*Record, error) {
+	rows, err := l.db.QueryContext(ctx,
+		`select id, tenant_id, name, type, state from services where tenant_id = ? order by name`,
+		tenantID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+	defer rows.Close()
+
+	var records []*Record
+	for rows.Next() {
+		rec := &Record{}
+		var typ, state string
+		if err := rows.Scan(&rec.ID, &rec.TenantID, &rec.Name, &typ, &state); err != nil {
+			return nil, fmt.Errorf("scan service: %w", err)
+		}
+		rec.Type = Type(typ)
+		rec.State = State(state)
+		records = append(records, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate services: %w", err)
+	}
+	return records, nil
+}
+
+func (l *Lifecycle) getWithNetwork(ctx context.Context, serviceID string) (*Record, string, error) {
+	rec := &Record{}
+	var typ, state, networkName string
+	err := l.db.QueryRowContext(ctx,
+		`select services.id, services.tenant_id, services.name, services.type, services.state, tenants.network_name
+		from services join tenants on tenants.id = services.tenant_id
+		where services.id = ?`,
+		serviceID,
+	).Scan(&rec.ID, &rec.TenantID, &rec.Name, &typ, &state, &networkName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, "", ErrNotFound
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("get service: %w", err)
+	}
+	rec.Type = Type(typ)
+	rec.State = State(state)
+	return rec, networkName, nil
+}

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -20,6 +20,8 @@ type ProvisionSpec struct {
 	Name       string
 	TenantID   string
 	Network    string
+	Image      string
+	Port       uint32
 	DBName     string
 	DBUser     string
 	DBPassword string
@@ -27,4 +29,5 @@ type ProvisionSpec struct {
 
 type Manager interface {
 	Provision(ctx context.Context, spec ProvisionSpec) (*paastryv1.Service, error)
+	Deploy(ctx context.Context, spec ProvisionSpec, serviceID string) (*paastryv1.Service, error)
 }

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -2,8 +2,8 @@ package service
 
 import (
 	"context"
+	"database/sql"
 
-	paastryv1 "github.com/LoriKarikari/paastry/gen/paastry/v1"
 	"github.com/LoriKarikari/paastry/internal/docker"
 )
 
@@ -16,7 +16,47 @@ type DockerClient interface {
 	ServiceRemove(ctx context.Context, id string) error
 }
 
+type Type string
+
+const (
+	TypePostgres Type = "postgres"
+	TypeApp      Type = "app"
+)
+
+type State string
+
+const StateRunning State = "running"
+
 type ProvisionSpec struct {
+	Name       string
+	TenantID   string
+	Type       Type
+	Image      string
+	Port       uint32
+	DBName     string
+	DBUser     string
+	DBPassword string
+}
+
+type Record struct {
+	ID       string
+	TenantID string
+	Name     string
+	Type     Type
+	State    State
+}
+
+type Lifecycle struct {
+	db       *sql.DB
+	managers map[Type]manager
+}
+
+type manager interface {
+	Provision(ctx context.Context, spec provisionerSpec) (*Record, error)
+	Deploy(ctx context.Context, spec provisionerSpec, serviceID string) (*Record, error)
+}
+
+type provisionerSpec struct {
 	Name       string
 	TenantID   string
 	Network    string
@@ -27,7 +67,12 @@ type ProvisionSpec struct {
 	DBPassword string
 }
 
-type Manager interface {
-	Provision(ctx context.Context, spec ProvisionSpec) (*paastryv1.Service, error)
-	Deploy(ctx context.Context, spec ProvisionSpec, serviceID string) (*paastryv1.Service, error)
+func NewLifecycle(db *sql.DB, docker DockerClient) *Lifecycle {
+	return &Lifecycle{
+		db: db,
+		managers: map[Type]manager{
+			TypePostgres: newPostgresManager(docker),
+			TypeApp:      newAppManager(docker),
+		},
+	}
 }

--- a/internal/service/postgres.go
+++ b/internal/service/postgres.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	paastryv1 "github.com/LoriKarikari/paastry/gen/paastry/v1"
 	"github.com/LoriKarikari/paastry/internal/docker"
 	"github.com/google/uuid"
 )
@@ -13,11 +12,11 @@ type postgresManager struct {
 	docker DockerClient
 }
 
-func NewPostgresManager(docker DockerClient) Manager {
+func newPostgresManager(docker DockerClient) manager {
 	return &postgresManager{docker: docker}
 }
 
-func (m *postgresManager) Provision(ctx context.Context, spec ProvisionSpec) (*paastryv1.Service, error) {
+func (m *postgresManager) Provision(ctx context.Context, spec provisionerSpec) (*Record, error) {
 	id := uuid.NewString()
 	svcName := "paastry-postgres-" + spec.Name
 
@@ -38,14 +37,15 @@ func (m *postgresManager) Provision(ctx context.Context, spec ProvisionSpec) (*p
 		return nil, fmt.Errorf("create postgres service: %w", err)
 	}
 
-	return &paastryv1.Service{
-		Id:    id,
-		Name:  spec.Name,
-		Type:  paastryv1.ServiceType_SERVICE_TYPE_POSTGRES,
-		State: paastryv1.ServiceState_SERVICE_STATE_RUNNING,
+	return &Record{
+		ID:       id,
+		TenantID: spec.TenantID,
+		Name:     spec.Name,
+		Type:     TypePostgres,
+		State:    StateRunning,
 	}, nil
 }
 
-func (m *postgresManager) Deploy(_ context.Context, _ ProvisionSpec, _ string) (*paastryv1.Service, error) {
+func (m *postgresManager) Deploy(_ context.Context, _ provisionerSpec, _ string) (*Record, error) {
 	return nil, fmt.Errorf("deploy not supported for postgres")
 }

--- a/internal/service/postgres.go
+++ b/internal/service/postgres.go
@@ -45,3 +45,7 @@ func (m *postgresManager) Provision(ctx context.Context, spec ProvisionSpec) (*p
 		State: paastryv1.ServiceState_SERVICE_STATE_RUNNING,
 	}, nil
 }
+
+func (m *postgresManager) Deploy(_ context.Context, _ ProvisionSpec, _ string) (*paastryv1.Service, error) {
+	return nil, fmt.Errorf("deploy not supported for postgres")
+}

--- a/internal/service/postgres_test.go
+++ b/internal/service/postgres_test.go
@@ -2,11 +2,13 @@ package service_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
 	"github.com/LoriKarikari/paastry/internal/docker"
 	"github.com/LoriKarikari/paastry/internal/service"
+	_ "modernc.org/sqlite"
 )
 
 type fakeDocker struct {
@@ -49,15 +51,16 @@ func (f *fakeDocker) NetworkRemove(_ context.Context, _ string) error {
 	return nil
 }
 
-func TestPostgresProvision(t *testing.T) {
+func TestLifecycleProvisionsPostgres(t *testing.T) {
 	ctx := context.Background()
+	db := newServiceDB(t)
 	dc := newFakeDocker()
-	mgr := service.NewPostgresManager(dc)
+	lifecycle := service.NewLifecycle(db, dc)
 
-	svc, err := mgr.Provision(ctx, service.ProvisionSpec{
+	rec, err := lifecycle.Provision(ctx, service.ProvisionSpec{
 		Name:       "mydb",
 		TenantID:   "tenant-1",
-		Network:    "paastry-tenant-default",
+		Type:       service.TypePostgres,
 		DBName:     "appdb",
 		DBUser:     "appuser",
 		DBPassword: "s3cret",
@@ -65,16 +68,24 @@ func TestPostgresProvision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provision: %v", err)
 	}
-	if svc.Name != "mydb" {
-		t.Fatalf("name = %q, want mydb", svc.Name)
+	if rec.Name != "mydb" {
+		t.Fatalf("name = %q, want mydb", rec.Name)
 	}
-	if svc.Id == "" {
+	if rec.ID == "" {
 		t.Fatal("service id is empty")
 	}
 
 	exists, _ := dc.ServiceExists(ctx, "paastry-postgres-mydb")
 	if !exists {
 		t.Fatal("docker service was not created")
+	}
+
+	got, err := lifecycle.Get(ctx, rec.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Type != service.TypePostgres || got.State != service.StateRunning {
+		t.Fatalf("got type/state = %s/%s", got.Type, got.State)
 	}
 }
 
@@ -104,14 +115,15 @@ func (failingDocker) NetworkRemove(_ context.Context, _ string) error {
 	return nil
 }
 
-func TestPostgresProvisionDockerError(t *testing.T) {
+func TestLifecycleProvisionDockerError(t *testing.T) {
 	ctx := context.Background()
-	mgr := service.NewPostgresManager(failingDocker{})
+	db := newServiceDB(t)
+	lifecycle := service.NewLifecycle(db, failingDocker{})
 
-	_, err := mgr.Provision(ctx, service.ProvisionSpec{
+	_, err := lifecycle.Provision(ctx, service.ProvisionSpec{
 		Name:       "mydb",
 		TenantID:   "tenant-1",
-		Network:    "paastry-tenant-default",
+		Type:       service.TypePostgres,
 		DBName:     "appdb",
 		DBUser:     "appuser",
 		DBPassword: "s3cret",
@@ -119,4 +131,32 @@ func TestPostgresProvisionDockerError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+}
+
+func newServiceDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(`
+		create table tenants (
+			id text primary key,
+			name text not null unique,
+			network_name text not null
+		);
+		insert into tenants (id, name, network_name) values ('tenant-1', 'default', 'paastry-tenant-default');
+		create table services (
+			id text primary key,
+			tenant_id text not null,
+			name text not null,
+			type text not null,
+			state text not null
+		);
+	`)
+	if err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	return db
 }

--- a/proto/paastry/v1/services.proto
+++ b/proto/paastry/v1/services.proto
@@ -8,6 +8,7 @@ option go_package = "github.com/LoriKarikari/paastry/gen/paastry/v1;paastryv1";
 
 service ServiceService {
   rpc ProvisionService(ProvisionServiceRequest) returns (ProvisionServiceResponse);
+  rpc DeployService(DeployServiceRequest) returns (DeployServiceResponse);
   rpc GetService(GetServiceRequest) returns (GetServiceResponse);
   rpc ListServices(ListServicesRequest) returns (ListServicesResponse);
 }
@@ -17,6 +18,7 @@ enum ServiceType {
   SERVICE_TYPE_POSTGRES = 1;
   SERVICE_TYPE_REDIS = 2;
   SERVICE_TYPE_VALKEY = 3;
+  SERVICE_TYPE_APP = 4;
 }
 
 enum ServiceState {
@@ -40,6 +42,8 @@ message ProvisionServiceRequest {
   string tenant_id = 1;
   string name = 2;
   ServiceType type = 3;
+  string image = 4;
+  int32 port = 5;
 }
 
 message ProvisionServiceResponse {
@@ -56,6 +60,16 @@ message GetServiceResponse {
 
 message ListServicesRequest {
   string tenant_id = 1;
+}
+
+message DeployServiceRequest {
+  string service_id = 1;
+  string image = 2;
+  int32 port = 3;
+}
+
+message DeployServiceResponse {
+  Service service = 1;
 }
 
 message ListServicesResponse {


### PR DESCRIPTION
Progress on #8.

- `SERVICE_TYPE_APP` proto enum value
- `DeployService` RPC with image and port
- App manager (`internal/service/app.go`) provisions Swarm services with ingress port
- `ServiceCreateSpec.Port` wired to `EndpointSpec` with ingress publish mode
- `ProvisionServiceRequest` extended with optional image/port fields
- Multi-manager dispatch by service type